### PR TITLE
Implement login page with NextAuth

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Providers from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,21 @@
 import Image from "next/image";
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 
-export default function Home() {
+export default async function Home() {
+  const session = await getServerSession(authOptions);
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <div className="row-start-1 self-end">
+        {session ? (
+          <form action="/api/auth/signout" method="post">
+            <button className="underline">Sign out</button>
+          </form>
+        ) : (
+          <Link className="underline" href="/login">Login</Link>
+        )
+      </div>
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"
@@ -12,6 +25,9 @@ export default function Home() {
           height={38}
           priority
         />
+        {session && (
+          <p className="text-sm">Logged in as {session.user?.name}</p>
+        )}
         <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
           <li className="mb-2 tracking-[-.01em]">
             Get started by editing{" "}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,6 @@
+"use client";
+import { SessionProvider } from "next-auth/react";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,43 @@
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import { prisma } from "./prisma";
+import bcrypt from "bcryptjs";
+import Credentials from "next-auth/providers/credentials";
+import type { NextAuthOptions } from "next-auth";
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: "jwt" },
+  providers: [
+    Credentials({
+      name: "Credentials",
+      credentials: {
+        username: { label: "Username", type: "text" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.username || !credentials.password) return null;
+        const user = await prisma.user.findUnique({
+          where: { username: credentials.username },
+        });
+        if (!user) return null;
+        const valid = await bcrypt.compare(credentials.password, user.passwordHash);
+        if (!valid) return null;
+        return { id: user.id, name: user.username, role: user.role } as any;
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.role = (user as any).role;
+      return token;
+    },
+    async session({ session, token }) {
+      session.user = {
+        ...(session.user || {}),
+        id: token.sub as string,
+        role: token.role as string,
+      };
+      return session;
+    },
+  },
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 export { default } from "next-auth/middleware";
 
 export const config = {
-  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|login).*)"],
 };

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -3,6 +3,7 @@ import 'next-auth';
 declare module 'next-auth' {
   interface Session {
     user: {
+      id?: string;
       role?: string;
     } & DefaultSession['user']
   }
@@ -10,6 +11,7 @@ declare module 'next-auth' {
 
 declare module 'next-auth/jwt' {
   interface JWT {
+    id?: string;
     role?: string;
   }
-} 
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth with Prisma credentials provider
- add API route for NextAuth
- wrap the app with SessionProvider
- expose login page and sign out option
- extend next-auth types
- exclude `/login` from auth middleware

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c306ff6f88321aaa8e8566a537a59