### PR TITLE
Fix JSX syntax error in home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default async function Home() {
           </form>
         ) : (
           <Link className="underline" href="/login">Login</Link>
-        )
+        )}
       </div>
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <Image


### PR DESCRIPTION
## Summary
- close expression in Home page conditional rendering

## Testing
- `npm run build` *(fails: next not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c32b49b208321bdb2d48ce7b2c196