### PR TITLE
Fix Prisma client import path

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,5 @@
-import { PrismaClient } from '@prisma/client';
+// Import the generated PrismaClient from the custom output path
+import { PrismaClient } from '@/app/generated/prisma';
 
 declare global {
   // -- prevents multiple instances in dev with hot-reload


### PR DESCRIPTION
## Summary
- update `lib/prisma.ts` to import PrismaClient from generated output

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c33d2ca4883218f89799b71f50a09