### PR TITLE
Fix dynamic NextAuth route

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,12 @@
 import NextAuth from "next-auth";
 import { authOptions } from "@/lib/auth";
 
+// NextAuth relies on runtime data such as cookies and request headers.
+// Mark this route as dynamic so Next.js doesn't attempt to prerender it.
+export const dynamic = "force-dynamic";
+// Ensure the handler runs on the Node runtime rather than the Edge runtime.
+export const runtime = "nodejs";
+
 const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };


### PR DESCRIPTION
## Summary
- declare `dynamic` and runtime on auth route

## Testing
- `pnpm install` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684c3661393483218a100bb602a18699