### PR TITLE
Fix Prisma client path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-
-/app/generated/prisma

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,5 +1,4 @@
-// Import the generated PrismaClient from the custom output path
-import { PrismaClient } from '@/app/generated/prisma';
+import { PrismaClient } from '@prisma/client';
 
 declare global {
   // -- prevents multiple instances in dev with hot-reload

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../app/generated/prisma"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- point `PrismaClient` import back to `@prisma/client`
- remove unused Prisma client output directory from `.gitignore`
- restore default Prisma generator output

## Testing
- `pnpm install --ignore-scripts`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_684c392581f08321baa8461347672cf7