### PR TITLE
Add admin user management

### DIFF
--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -5,8 +5,9 @@ import { authOptions } from "@/lib/auth";
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: { id: string } }
 ) {
+  const { params } = context;
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== "admin") {
     return new NextResponse("Unauthorized", { status: 403 });

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  await prisma.user.delete({ where: { id: params.id } });
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,10 +1,10 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
 
 export async function DELETE(
-  req: Request,
+  req: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const session = await getServerSession(authOptions);

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,17 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
 
 export async function DELETE(
-  req: NextRequest,
-  context: { params: { id: string } }
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const { params } = context;
+  const { id } = await params;
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== "admin") {
     return new NextResponse("Unauthorized", { status: 403 });
   }
-  await prisma.user.delete({ where: { id: params.id } });
+  await prisma.user.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
@@ -15,7 +15,7 @@ export async function GET() {
   return NextResponse.json(users);
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== "admin") {
     return new NextResponse("Unauthorized", { status: 403 });

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const users = await prisma.user.findMany({
+    select: { id: true, username: true, role: true },
+  });
+  return NextResponse.json(users);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { username, password, role } = await req.json();
+  if (!username || !password) {
+    return new NextResponse("Missing fields", { status: 400 });
+  }
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({
+    data: { username, passwordHash, role: role === "admin" ? "admin" : "user" },
+    select: { id: true, username: true, role: true },
+  });
+  return NextResponse.json(user, { status: 201 });
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
@@ -15,7 +15,7 @@ export async function GET() {
   return NextResponse.json(users);
 }
 
-export async function POST(req: NextRequest) {
+export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== "admin") {
     return new NextResponse("Unauthorized", { status: 403 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,14 @@ export default async function Home() {
           priority
         />
         {session && (
-          <p className="text-sm">Logged in as {session.user?.name}</p>
+          <>
+            <p className="text-sm">Logged in as {session.user?.name}</p>
+            {session.user?.role === "admin" && (
+              <Link className="underline" href="/users">
+                Users
+              </Link>
+            )}
+          </>
         )}
         <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
           <li className="mb-2 tracking-[-.01em]">

--- a/app/users/UsersClient.tsx
+++ b/app/users/UsersClient.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useEffect, useState, FormEvent } from "react";
+
+export type User = { id: string; username: string; role: string };
+
+export default function UsersClient({
+  initialUsers,
+}: {
+  initialUsers: User[];
+}) {
+  const [users, setUsers] = useState<User[]>(initialUsers);
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [role, setRole] = useState("user");
+
+  async function refresh() {
+    const res = await fetch("/api/users");
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data);
+    }
+  }
+
+  async function addUser(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password, role }),
+    });
+    setUsername("");
+    setPassword("");
+    setRole("user");
+    refresh();
+  }
+
+  async function deleteUser(id: string) {
+    await fetch(`/api/users/${id}`, { method: "DELETE" });
+    setUsers((u) => u.filter((user) => user.id !== id));
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold">Users</h1>
+      <form onSubmit={addUser} className="space-y-2 border p-4 rounded">
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          className="w-full border p-2 rounded"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <select
+          className="w-full border p-2 rounded"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+        >
+          <option value="user">user</option>
+          <option value="admin">admin</option>
+        </select>
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+          Add User
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {users.map((u) => (
+          <li key={u.id} className="flex justify-between border p-2 rounded">
+            <span>
+              {u.username} ({u.role})
+            </span>
+            <button
+              onClick={() => deleteUser(u.id)}
+              className="text-red-600"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/users/UsersClient.tsx
+++ b/app/users/UsersClient.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, FormEvent } from "react";
+import { useState, FormEvent } from "react";
 
 export type User = { id: string; username: string; role: string };
 

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,0 +1,16 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import UsersClient from "./UsersClient";
+
+export default async function UsersPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    redirect("/");
+  }
+  const users = await prisma.user.findMany({
+    select: { id: true, username: true, role: true },
+  });
+  return <UsersClient initialUsers={users} />;
+}


### PR DESCRIPTION
## Summary
- add Users link on homepage for admins
- implement `/users` page to list, create and delete users
- add API routes for listing, creating and deleting users

## Testing
- `npx tsc --noEmit`
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f4de5348321acf5d6888625f237