### PR TITLE
Implement phase 3 student management

### DIFF
--- a/app/api/students/[id]/route.ts
+++ b/app/api/students/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { name, batch, totalFee } = await req.json();
+  try {
+    const student = await prisma.student.update({
+      where: { id },
+      data: { name, batch, totalFee: totalFee.toString() },
+      select: { id: true, name: true, batch: true, totalFee: true },
+    });
+    return NextResponse.json(student);
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return new NextResponse("Student already exists", { status: 400 });
+    }
+    throw err;
+  }
+}
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> }
+) {
+  return PUT(req, ctx);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  await prisma.student.delete({ where: { id } });
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/students/route.ts
+++ b/app/api/students/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const students = await prisma.student.findMany({
+    select: { id: true, name: true, batch: true, totalFee: true },
+  });
+  return NextResponse.json(students);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { name, batch, totalFee } = await req.json();
+  if (!name || !batch || totalFee === undefined) {
+    return new NextResponse("Missing fields", { status: 400 });
+  }
+  try {
+    const student = await prisma.student.create({
+      data: { name, batch, totalFee: totalFee.toString() },
+      select: { id: true, name: true, batch: true, totalFee: true },
+    });
+    return NextResponse.json(student, { status: 201 });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return new NextResponse("Student already exists", { status: 400 });
+    }
+    throw err;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,9 @@ export default async function Home() {
         {session && (
           <>
             <p className="text-sm">Logged in as {session.user?.name}</p>
+            <Link className="underline" href="/students">
+              Students
+            </Link>
             {session.user?.role === "admin" && (
               <Link className="underline" href="/users">
                 Users

--- a/app/students/StudentsClient.tsx
+++ b/app/students/StudentsClient.tsx
@@ -1,0 +1,94 @@
+"use client";
+import { useState, FormEvent } from "react";
+
+export type Student = {
+  id: string;
+  name: string;
+  batch: string;
+  totalFee: string;
+};
+
+export default function StudentsClient({
+  initialStudents,
+  isAdmin,
+}: {
+  initialStudents: Student[];
+  isAdmin: boolean;
+}) {
+  const [students, setStudents] = useState<Student[]>(initialStudents);
+  const [name, setName] = useState("");
+  const [batch, setBatch] = useState("");
+  const [totalFee, setTotalFee] = useState("");
+
+  async function refresh() {
+    const res = await fetch("/api/students");
+    if (res.ok) {
+      const data = await res.json();
+      setStudents(data);
+    }
+  }
+
+  async function addStudent(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch("/api/students", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, batch, totalFee }),
+    });
+    setName("");
+    setBatch("");
+    setTotalFee("");
+    refresh();
+  }
+
+  async function deleteStudent(id: string) {
+    await fetch(`/api/students/${id}`, { method: "DELETE" });
+    setStudents((s) => s.filter((st) => st.id !== id));
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold">Students</h1>
+      <form onSubmit={addStudent} className="space-y-2 border p-4 rounded">
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Batch"
+          value={batch}
+          onChange={(e) => setBatch(e.target.value)}
+        />
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Total Fee"
+          value={totalFee}
+          onChange={(e) => setTotalFee(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+          Add Student
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {students.map((s) => (
+          <li key={s.id} className="flex justify-between border p-2 rounded">
+            <span>
+              {s.name} - {s.batch} - {s.totalFee}
+            </span>
+            {isAdmin && (
+              <button
+                onClick={() => deleteStudent(s.id)}
+                className="text-red-600"
+              >
+                Delete
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -9,9 +9,13 @@ export default async function StudentsPage() {
   if (!session) {
     redirect("/login");
   }
-  const students = await prisma.student.findMany({
+  const dbStudents = await prisma.student.findMany({
     select: { id: true, name: true, batch: true, totalFee: true },
   });
+  const students = dbStudents.map((s) => ({
+    ...s,
+    totalFee: s.totalFee.toString(),
+  }));
   return (
     <StudentsClient
       initialStudents={students}

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -1,0 +1,21 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import StudentsClient from "./StudentsClient";
+
+export default async function StudentsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect("/login");
+  }
+  const students = await prisma.student.findMany({
+    select: { id: true, name: true, batch: true, totalFee: true },
+  });
+  return (
+    <StudentsClient
+      initialStudents={students}
+      isAdmin={session.user.role === "admin"}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- implement Student CRUD API
- add pages to list/create students
- link student page from home

## Testing
- `pnpm lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684c5980b56883219099fb632b2e1006