### PR TITLE
Implement user editing and duplicate check

### DIFF
--- a/Plan.MD
+++ b/Plan.MD
@@ -21,7 +21,7 @@ The project aims to implement a complete fee management system for students. Bel
 - Restrict access by checking `session.user.role === 'admin'`.
 :::
 
-## Phase 3 – Student Record Management *(pending)*
+## Phase 3 – Student Record Management *(done)*
 - Allow a signed-in user to create student records (name, batch, totalFee). Only admins can edit or delete them.
 
 :::task-stub{title="Implement Student CRUD"}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
+import bcrypt from "bcryptjs";
+import { Prisma } from "@prisma/client";
 
 export async function DELETE(
   request: Request,
@@ -15,3 +17,40 @@ export async function DELETE(
   await prisma.user.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { username, role, password } = await req.json();
+  const data: any = {
+    username,
+    role: role === "admin" ? "admin" : "user",
+  };
+  if (password) {
+    data.passwordHash = await bcrypt.hash(password, 10);
+  }
+  try {
+    const user = await prisma.user.update({
+      where: { id },
+      data,
+      select: { id: true, username: true, role: true },
+    });
+    return NextResponse.json(user);
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return new NextResponse("Username already exists", { status: 400 });
+    }
+    throw err;
+  }
+}
+
+export const PATCH = PUT;

--- a/app/students/StudentsClient.tsx
+++ b/app/students/StudentsClient.tsx
@@ -19,6 +19,7 @@ export default function StudentsClient({
   const [name, setName] = useState("");
   const [batch, setBatch] = useState("");
   const [totalFee, setTotalFee] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   async function refresh() {
     const res = await fetch("/api/students");
@@ -30,11 +31,18 @@ export default function StudentsClient({
 
   async function addStudent(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    await fetch("/api/students", {
+    setError(null);
+    const res = await fetch("/api/students", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, batch, totalFee }),
     });
+    if (!res.ok) {
+      const text = await res.text();
+      setError(text);
+      alert(text);
+      return;
+    }
     setName("");
     setBatch("");
     setTotalFee("");
@@ -71,6 +79,7 @@ export default function StudentsClient({
         <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
           Add Student
         </button>
+        {error && <p className="text-red-600">{error}</p>}
       </form>
       <ul className="space-y-2">
         {students.map((s) => (

--- a/app/users/UsersClient.tsx
+++ b/app/users/UsersClient.tsx
@@ -12,6 +12,10 @@ export default function UsersClient({
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [role, setRole] = useState("user");
+  const [editing, setEditing] = useState<User | null>(null);
+  const [editUsername, setEditUsername] = useState("");
+  const [editPassword, setEditPassword] = useState("");
+  const [editRole, setEditRole] = useState("user");
 
   async function refresh() {
     const res = await fetch("/api/users");
@@ -37,6 +41,30 @@ export default function UsersClient({
   async function deleteUser(id: string) {
     await fetch(`/api/users/${id}`, { method: "DELETE" });
     setUsers((u) => u.filter((user) => user.id !== id));
+  }
+
+  function startEdit(user: User) {
+    setEditing(user);
+    setEditUsername(user.username);
+    setEditRole(user.role);
+    setEditPassword("");
+  }
+
+  async function updateUser(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!editing) return;
+    await fetch(`/api/users/${editing.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: editUsername,
+        role: editRole,
+        password: editPassword || undefined,
+      }),
+    });
+    setEditing(null);
+    setEditPassword("");
+    refresh();
   }
 
   return (
@@ -70,16 +98,64 @@ export default function UsersClient({
       </form>
       <ul className="space-y-2">
         {users.map((u) => (
-          <li key={u.id} className="flex justify-between border p-2 rounded">
-            <span>
-              {u.username} ({u.role})
-            </span>
-            <button
-              onClick={() => deleteUser(u.id)}
-              className="text-red-600"
-            >
-              Delete
-            </button>
+          <li key={u.id} className="border p-2 rounded space-y-2">
+            {editing && editing.id === u.id ? (
+              <form onSubmit={updateUser} className="space-y-2">
+                <input
+                  className="w-full border p-2 rounded"
+                  placeholder="Username"
+                  value={editUsername}
+                  onChange={(e) => setEditUsername(e.target.value)}
+                />
+                <input
+                  type="password"
+                  className="w-full border p-2 rounded"
+                  placeholder="Password (leave blank to keep)"
+                  value={editPassword}
+                  onChange={(e) => setEditPassword(e.target.value)}
+                />
+                <select
+                  className="w-full border p-2 rounded"
+                  value={editRole}
+                  onChange={(e) => setEditRole(e.target.value)}
+                >
+                  <option value="user">user</option>
+                  <option value="admin">admin</option>
+                </select>
+                <div className="flex gap-2">
+                  <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditing(null)}
+                    className="px-4 py-2 bg-gray-300 rounded"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div className="flex justify-between items-center">
+                <span>
+                  {u.username} ({u.role})
+                </span>
+                <div className="space-x-2">
+                  <button
+                    onClick={() => startEdit(u)}
+                    className="text-blue-600"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteUser(u.id)}
+                    className="text-red-600"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- allow admins to edit users via `/api/users/[id]` PUT route and new UI controls
- show popup when attempting to create duplicate students
- mark Phase 3 as complete

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c6131099883219f35ad405514956b