### PR TITLE
Implement transactions and concession approval

### DIFF
--- a/Plan.MD
+++ b/Plan.MD
@@ -31,7 +31,7 @@ The project aims to implement a complete fee management system for students. Bel
 - Protect edit and delete actions with role checks for admins.
 :::
 
-## Phase 4 – Transactions & Concessions *(pending)*
+## Phase 4 – Transactions & Concessions *(done)*
 - Record payments and concessions in the `Transaction` table. Concessions require admin approval.
 
 :::task-stub{title="Add transaction handling"}

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { approved } = await req.json();
+  const txn = await prisma.transaction.update({
+    where: { id },
+    data: { approved: !!approved },
+    select: {
+      id: true,
+      approved: true,
+    },
+  });
+  return NextResponse.json(txn);
+}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const txns = await prisma.transaction.findMany({
+    select: {
+      id: true,
+      studentId: true,
+      student: { select: { name: true, batch: true } },
+      type: true,
+      amount: true,
+      mode: true,
+      approved: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  const data = txns.map((t) => ({
+    ...t,
+    amount: t.amount.toString(),
+    createdAt: t.createdAt.toISOString(),
+  }));
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { studentId, type, amount, mode } = await req.json();
+  if (!studentId || !type || !amount) {
+    return new NextResponse("Missing fields", { status: 400 });
+  }
+  if (type !== "payment" && type !== "concession") {
+    return new NextResponse("Invalid type", { status: 400 });
+  }
+  if (type === "payment" && mode !== "cash" && mode !== "online") {
+    return new NextResponse("Invalid payment mode", { status: 400 });
+  }
+  try {
+    const txn = await prisma.transaction.create({
+      data: {
+        studentId,
+        createdById: session.user.id!,
+        type,
+        amount: amount.toString(),
+        mode: type === "payment" ? mode : null,
+        approved: type === "payment" ? true : false,
+      },
+      select: {
+        id: true,
+        studentId: true,
+        student: { select: { name: true, batch: true } },
+        type: true,
+        amount: true,
+        mode: true,
+        approved: true,
+        createdAt: true,
+      },
+    });
+    return NextResponse.json(
+      {
+        ...txn,
+        amount: txn.amount.toString(),
+        createdAt: txn.createdAt.toISOString(),
+      },
+      { status: 201 }
+    );
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2003"
+    ) {
+      return new NextResponse("Invalid student", { status: 400 });
+    }
+    throw err;
+  }
+}

--- a/app/approvals/ApprovalsClient.tsx
+++ b/app/approvals/ApprovalsClient.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useState } from "react";
+
+export type Approval = {
+  id: string;
+  student: { name: string; batch: string };
+  amount: string;
+};
+
+export default function ApprovalsClient({ initialApprovals }: { initialApprovals: Approval[] }) {
+  const [items, setItems] = useState<Approval[]>(initialApprovals);
+
+  async function approve(id: string) {
+    await fetch(`/api/transactions/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ approved: true }),
+    });
+    setItems((prev) => prev.filter((a) => a.id !== id));
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold">Approve Concessions</h1>
+      <ul className="space-y-2">
+        {items.map((a) => (
+          <li key={a.id} className="border p-2 rounded flex justify-between">
+            <span>
+              {a.student.name} - {a.student.batch}: {a.amount}
+            </span>
+            <button onClick={() => approve(a.id)} className="text-blue-600">
+              Approve
+            </button>
+          </li>
+        ))}
+        {items.length === 0 && <p>No pending concessions</p>}
+      </ul>
+    </div>
+  );
+}

--- a/app/approvals/page.tsx
+++ b/app/approvals/page.tsx
@@ -1,0 +1,25 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import ApprovalsClient from "./ApprovalsClient";
+
+export default async function ApprovalsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    redirect("/");
+  }
+  const pending = await prisma.transaction.findMany({
+    where: { type: "concession", approved: false },
+    select: {
+      id: true,
+      student: { select: { name: true, batch: true } },
+      amount: true,
+    },
+  });
+  const approvals = pending.map((p) => ({
+    ...p,
+    amount: p.amount.toString(),
+  }));
+  return <ApprovalsClient initialApprovals={approvals} />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,9 +31,17 @@ export default async function Home() {
             <Link className="underline" href="/students">
               Students
             </Link>
+            <Link className="underline" href="/transactions">
+              Transactions
+            </Link>
             {session.user?.role === "admin" && (
               <Link className="underline" href="/users">
                 Users
+              </Link>
+            )}
+            {session.user?.role === "admin" && (
+              <Link className="underline" href="/approvals">
+                Approvals
               </Link>
             )}
           </>

--- a/app/transactions/TransactionsClient.tsx
+++ b/app/transactions/TransactionsClient.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { useState, FormEvent } from "react";
+
+export type Transaction = {
+  id: string;
+  studentId: string;
+  student: { name: string; batch: string };
+  type: string;
+  amount: string;
+  mode: string | null;
+  approved: boolean;
+  createdAt: string;
+};
+
+export type Student = { id: string; name: string; batch: string };
+
+export default function TransactionsClient({
+  students,
+  initialTransactions,
+  isAdmin,
+}: {
+  students: Student[];
+  initialTransactions: Transaction[];
+  isAdmin: boolean;
+}) {
+  const [transactions, setTransactions] = useState<Transaction[]>(
+    initialTransactions
+  );
+  const [studentId, setStudentId] = useState(students[0]?.id || "");
+  const [type, setType] = useState("payment");
+  const [amount, setAmount] = useState("");
+  const [mode, setMode] = useState("cash");
+
+  async function refresh() {
+    const res = await fetch("/api/transactions");
+    if (res.ok) {
+      const data = await res.json();
+      setTransactions(data);
+    }
+  }
+
+  async function addTransaction(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch("/api/transactions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ studentId, type, amount, mode }),
+    });
+    setAmount("");
+    refresh();
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold">Transactions</h1>
+      <form onSubmit={addTransaction} className="space-y-2 border p-4 rounded">
+        <select
+          className="w-full border p-2 rounded"
+          value={studentId}
+          onChange={(e) => setStudentId(e.target.value)}
+        >
+          {students.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name} - {s.batch}
+            </option>
+          ))}
+        </select>
+        <select
+          className="w-full border p-2 rounded"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+        >
+          <option value="payment">payment</option>
+          <option value="concession">concession</option>
+        </select>
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        {type === "payment" && (
+          <select
+            className="w-full border p-2 rounded"
+            value={mode}
+            onChange={(e) => setMode(e.target.value)}
+          >
+            <option value="cash">cash</option>
+            <option value="online">online</option>
+          </select>
+        )}
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+          Add Transaction
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {transactions.map((t) => (
+          <li key={t.id} className="border p-2 rounded">
+            <div className="flex justify-between">
+              <span>
+                {t.student.name} - {t.student.batch} : {t.type} {t.amount} {t.mode ? `(${t.mode})` : ""}
+              </span>
+              {!t.approved && t.type === "concession" && <span className="text-orange-600">Pending</span>}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -1,0 +1,40 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import TransactionsClient from "./TransactionsClient";
+
+export default async function TransactionsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect("/login");
+  }
+  const students = await prisma.student.findMany({
+    select: { id: true, name: true, batch: true },
+  });
+  const txns = await prisma.transaction.findMany({
+    select: {
+      id: true,
+      studentId: true,
+      student: { select: { name: true, batch: true } },
+      type: true,
+      amount: true,
+      mode: true,
+      approved: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  const transactions = txns.map((t) => ({
+    ...t,
+    amount: t.amount.toString(),
+    createdAt: t.createdAt.toISOString(),
+  }));
+  return (
+    <TransactionsClient
+      students={students}
+      initialTransactions={transactions}
+      isAdmin={session.user.role === "admin"}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- support payments and concession requests
- list and add transactions in a new page
- add admin page for approving concessions
- expose API for creating transactions and approving them
- mark Phase 4 as done in the project plan

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d10c83bc08321846597d7c6cd3ac6