### PR TITLE
Implement reporting endpoints and pages

### DIFF
--- a/app/api/reports/balance/route.ts
+++ b/app/api/reports/balance/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { searchParams } = new URL(req.url);
+  const studentId = searchParams.get("studentId");
+  const name = searchParams.get("name");
+  const batch = searchParams.get("batch");
+
+  let students;
+  if (studentId) {
+    const s = await prisma.student.findUnique({
+      where: { id: studentId },
+      select: { id: true, name: true, batch: true, totalFee: true },
+    });
+    students = s ? [s] : [];
+  } else {
+    students = await prisma.student.findMany({
+      where: {
+        ...(name ? { name } : {}),
+        ...(batch ? { batch } : {}),
+      },
+      select: { id: true, name: true, batch: true, totalFee: true },
+    });
+  }
+
+  const results = [] as { id: string; name: string; batch: string; balance: string }[];
+  for (const s of students) {
+    const agg = await prisma.transaction.aggregate({
+      where: { studentId: s.id, approved: true },
+      _sum: { amount: true },
+    });
+    const paid = parseFloat(agg._sum.amount?.toString() || "0");
+    const total = parseFloat(s.totalFee.toString());
+    const bal = (total - paid).toFixed(2);
+    results.push({ id: s.id, name: s.name, batch: s.batch, balance: bal });
+  }
+  return NextResponse.json(results);
+}

--- a/app/api/reports/transactions/route.ts
+++ b/app/api/reports/transactions/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { searchParams } = new URL(req.url);
+  const name = searchParams.get("name");
+  const batch = searchParams.get("batch");
+  const start = searchParams.get("start");
+  const end = searchParams.get("end");
+
+  const where: Prisma.TransactionWhereInput = {};
+  if (name || batch) {
+    where.student = {
+      ...(name ? { name } : {}),
+      ...(batch ? { batch } : {}),
+    };
+  }
+  if (start || end) {
+    where.createdAt = {};
+    if (start) (where.createdAt as any).gte = new Date(start);
+    if (end) {
+      const d = new Date(end);
+      d.setDate(d.getDate() + 1);
+      (where.createdAt as any).lte = d;
+    }
+  }
+
+  const txns = await prisma.transaction.findMany({
+    where,
+    select: {
+      id: true,
+      student: { select: { name: true, batch: true } },
+      type: true,
+      amount: true,
+      mode: true,
+      approved: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  const transactions = txns.map((t) => ({
+    ...t,
+    amount: t.amount.toString(),
+    createdAt: t.createdAt.toISOString(),
+  }));
+
+  const modeTotalsRaw = await prisma.transaction.groupBy({
+    by: ["mode"],
+    where: { ...where, type: "payment", mode: { not: null } },
+    _sum: { amount: true },
+  });
+  const totals = modeTotalsRaw.map((m) => ({
+    mode: m.mode!,
+    amount: m._sum.amount?.toString() || "0",
+  }));
+
+  return NextResponse.json({ transactions, totals });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,6 +34,9 @@ export default async function Home() {
             <Link className="underline" href="/transactions">
               Transactions
             </Link>
+            <Link className="underline" href="/reports">
+              Reports
+            </Link>
             {session.user?.role === "admin" && (
               <Link className="underline" href="/users">
                 Users

--- a/app/reports/ReportsClient.tsx
+++ b/app/reports/ReportsClient.tsx
@@ -1,0 +1,149 @@
+"use client";
+import { useState, FormEvent } from "react";
+
+export type Student = { id: string; name: string; batch: string };
+export type Transaction = {
+  id: string;
+  student: { name: string; batch: string };
+  type: string;
+  amount: string;
+  mode: string | null;
+  approved: boolean;
+  createdAt: string;
+};
+export type Balance = { id: string; name: string; batch: string; balance: string };
+
+export default function ReportsClient({ students }: { students: Student[] }) {
+  const batches = Array.from(new Set(students.map((s) => s.batch)));
+  const [batch, setBatch] = useState("");
+  const [name, setName] = useState("");
+  const [balances, setBalances] = useState<Balance[]>([]);
+
+  const [tBatch, setTBatch] = useState("");
+  const [tName, setTName] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [totals, setTotals] = useState<{ mode: string; amount: string }[]>([]);
+
+  async function getBalances(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (batch) params.append("batch", batch);
+    if (name) params.append("name", name);
+    const res = await fetch(`/api/reports/balance?${params.toString()}`);
+    if (res.ok) {
+      const data = await res.json();
+      setBalances(data);
+    }
+  }
+
+  async function getTransactions(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (tBatch) params.append("batch", tBatch);
+    if (tName) params.append("name", tName);
+    if (start) params.append("start", start);
+    if (end) params.append("end", end);
+    const res = await fetch(`/api/reports/transactions?${params.toString()}`);
+    if (res.ok) {
+      const data = await res.json();
+      setTransactions(data.transactions);
+      setTotals(data.totals);
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-3xl mx-auto">
+      <h1 className="text-xl font-bold">Reports</h1>
+
+      <form onSubmit={getBalances} className="space-y-2 border p-4 rounded">
+        <h2 className="font-semibold">Student Balances</h2>
+        <select
+          className="w-full border p-2 rounded"
+          value={batch}
+          onChange={(e) => setBatch(e.target.value)}
+        >
+          <option value="">All Batches</option>
+          {batches.map((b) => (
+            <option key={b} value={b}>
+              {b}
+            </option>
+          ))}
+        </select>
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Name (optional)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+          Get Balances
+        </button>
+      </form>
+      <ul className="space-y-1">
+        {balances.map((b) => (
+          <li key={b.id} className="border p-2 rounded">
+            {b.name} - {b.batch}: {b.balance}
+          </li>
+        ))}
+        {balances.length === 0 && <p>No results</p>}
+      </ul>
+
+      <form onSubmit={getTransactions} className="space-y-2 border p-4 rounded">
+        <h2 className="font-semibold">Transactions</h2>
+        <select
+          className="w-full border p-2 rounded"
+          value={tBatch}
+          onChange={(e) => setTBatch(e.target.value)}
+        >
+          <option value="">All Batches</option>
+          {batches.map((b) => (
+            <option key={b} value={b}>
+              {b}
+            </option>
+          ))}
+        </select>
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Name (optional)"
+          value={tName}
+          onChange={(e) => setTName(e.target.value)}
+        />
+        <div className="flex gap-2">
+          <input
+            type="date"
+            className="w-full border p-2 rounded"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+          />
+          <input
+            type="date"
+            className="w-full border p-2 rounded"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+          />
+        </div>
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+          Get Transactions
+        </button>
+      </form>
+      <ul className="space-y-1">
+        {transactions.map((t) => (
+          <li key={t.id} className="border p-2 rounded">
+            {t.createdAt.slice(0, 10)} - {t.student.name} - {t.student.batch}: {t.type}{" "}
+            {t.amount} {t.mode ? `(${t.mode})` : ""}
+          </li>
+        ))}
+        {transactions.length === 0 && <p>No transactions</p>}
+      </ul>
+      {totals.length > 0 && (
+        <div className="space-y-1">
+          {totals.map((t) => (
+            <p key={t.mode}>Total {t.mode}: {t.amount}</p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,0 +1,16 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import ReportsClient from "./ReportsClient";
+
+export default async function ReportsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect("/login");
+  }
+  const students = await prisma.student.findMany({
+    select: { id: true, name: true, batch: true },
+  });
+  return <ReportsClient students={students} />;
+}


### PR DESCRIPTION
## Summary
- add API routes to compute balances and filtered transactions
- build Reports page with balance and transaction queries
- link Reports from home

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Could not download Prisma engines)*

------
https://chatgpt.com/codex/tasks/task_e_684d15c6e92483219e90f148a64ded66