### PR TITLE
Add CSV student import and improved search

### DIFF
--- a/app/api/reports/balance/route.ts
+++ b/app/api/reports/balance/route.ts
@@ -23,7 +23,9 @@ export async function GET(req: Request) {
   } else {
     students = await prisma.student.findMany({
       where: {
-        ...(name ? { name } : {}),
+        ...(name
+          ? { name: { contains: name, mode: "insensitive" } }
+          : {}),
         ...(batch ? { batch } : {}),
       },
       select: { id: true, name: true, batch: true, totalFee: true },

--- a/app/api/reports/transactions/route.ts
+++ b/app/api/reports/transactions/route.ts
@@ -18,7 +18,9 @@ export async function GET(req: Request) {
   const where: Prisma.TransactionWhereInput = {};
   if (name || batch) {
     where.student = {
-      ...(name ? { name } : {}),
+      ...(name
+        ? { name: { contains: name, mode: "insensitive" } }
+        : {}),
       ...(batch ? { batch } : {}),
     };
   }

--- a/app/api/students/import/route.ts
+++ b/app/api/students/import/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { students } = await req.json();
+  if (!Array.isArray(students)) {
+    return new NextResponse("Invalid data", { status: 400 });
+  }
+  const data = students
+    .filter((s: any) => s && s.name && s.batch && s.totalFee !== undefined)
+    .map((s: any) => ({
+      name: s.name,
+      batch: s.batch,
+      totalFee: s.totalFee.toString(),
+    }));
+  if (data.length === 0) {
+    return new NextResponse("No valid students", { status: 400 });
+  }
+  await prisma.student.createMany({ data, skipDuplicates: true });
+  return new NextResponse(null, { status: 204 });
+}


### PR DESCRIPTION
## Summary
- add API route to import multiple students
- allow CSV uploads from the Students page
- support partial name searches in reports

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm install` *(fails: unable to fetch prisma engine binaries)*

------
https://chatgpt.com/codex/tasks/task_e_684d1a7fa3b883219417cf65b0223c06