### PR TITLE
Show popup on CSV import failure

### DIFF
--- a/app/students/StudentsClient.tsx
+++ b/app/students/StudentsClient.tsx
@@ -66,15 +66,22 @@ export default function StudentsClient({
       const [n, b, a] = r.split(",");
       return { name: n?.trim(), batch: b?.trim(), totalFee: a?.trim() };
     });
-    const res = await fetch("/api/students/import", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ students }),
-    });
-    if (!res.ok) {
-      const text = await res.text();
-      setImportError(text);
-      alert(text);
+    try {
+      const res = await fetch("/api/students/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ students }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        setImportError(text);
+        alert(`Import failed: ${text}`);
+        return;
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setImportError(msg);
+      alert(`Import failed: ${msg}`);
       return;
     }
     setCsvFile(null);


### PR DESCRIPTION
## Summary
- handle errors when uploading CSV by showing a popup with the reason

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: prisma binaries blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d1ed3472c8321bf18ece5dd35c26b