### PR TITLE
Implement student search and record pages

### DIFF
--- a/app/Header.tsx
+++ b/app/Header.tsx
@@ -1,17 +1,19 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import SearchBar from "./SearchBar";
 
 export default async function Header() {
   const session = await getServerSession(authOptions);
   return (
     <header className="bg-indigo-700 text-white">
-      <nav className="max-w-5xl mx-auto flex items-center justify-between p-4">
+      <nav className="max-w-5xl mx-auto flex flex-wrap items-center justify-between p-4 gap-4">
         <Link href="/" className="font-semibold text-lg leading-tight">
           Jagannatha Group B.Ed Colleges
           <span className="block text-sm font-normal">Fee Portal</span>
         </Link>
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-4 flex-wrap">
+          {session && <SearchBar />}
           {session && (
             <>
               <Link href="/students" className="hover:underline">Students</Link>

--- a/app/SearchBar.tsx
+++ b/app/SearchBar.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function SearchBar() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Array<{ id: string; name: string; batch: string }>>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setResults([]);
+      return;
+    }
+    const controller = new AbortController();
+    fetch(`/api/students?q=${encodeURIComponent(q)}`, { signal: controller.signal })
+      .then((res) => res.ok ? res.json() : [])
+      .then((data) => setResults(data))
+      .catch(() => {});
+    return () => controller.abort();
+  }, [query]);
+
+  function select(id: string) {
+    setQuery("");
+    setResults([]);
+    router.push(`/students/${id}`);
+  }
+
+  return (
+    <div className="relative">
+      <input
+        className="border rounded p-1 text-black"
+        placeholder="Search students"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      {results.length > 0 && (
+        <ul className="absolute z-10 bg-white text-black border w-56 max-h-60 overflow-auto">
+          {results.map((s) => (
+            <li
+              key={s.id}
+              className="px-2 py-1 hover:bg-gray-200 cursor-pointer"
+              onClick={() => select(s.id)}
+            >
+              {s.name} - {s.batch}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/api/reports/balance/route.ts
+++ b/app/api/reports/balance/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
 
 export async function GET(req: Request) {
   const session = await getServerSession(authOptions);
@@ -24,7 +25,7 @@ export async function GET(req: Request) {
     students = await prisma.student.findMany({
       where: {
         ...(name
-          ? { name: { contains: name, mode: "insensitive" } }
+          ? { name: { contains: name, mode: Prisma.QueryMode.insensitive } }
           : {}),
         ...(batch ? { batch } : {}),
       },

--- a/app/api/reports/transactions/route.ts
+++ b/app/api/reports/transactions/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: Request) {
   if (name || batch) {
     where.student = {
       ...(name
-        ? { name: { contains: name, mode: "insensitive" } }
+        ? { name: { contains: name, mode: Prisma.QueryMode.insensitive } }
         : {}),
       ...(batch ? { batch } : {}),
     };

--- a/app/api/students/route.ts
+++ b/app/api/students/route.ts
@@ -4,13 +4,20 @@ import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
 import { Prisma } from "@prisma/client";
 
-export async function GET() {
+export async function GET(req: Request) {
   const session = await getServerSession(authOptions);
   if (!session) {
     return new NextResponse("Unauthorized", { status: 403 });
   }
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q") || undefined;
+  const where = q
+    ? { name: { contains: q, mode: "insensitive" } }
+    : undefined;
   const students = await prisma.student.findMany({
+    where,
     select: { id: true, name: true, batch: true, totalFee: true },
+    orderBy: { name: "asc" },
   });
   return NextResponse.json(students);
 }

--- a/app/api/students/route.ts
+++ b/app/api/students/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: Request) {
   const url = new URL(req.url);
   const q = url.searchParams.get("q") || undefined;
   const where = q
-    ? { name: { contains: q, mode: "insensitive" } }
+    ? { name: { contains: q, mode: Prisma.QueryMode.insensitive } }
     : undefined;
   const students = await prisma.student.findMany({
     where,

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -24,6 +24,52 @@ export async function PATCH(
   return NextResponse.json(txn);
 }
 
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "admin") {
+    return new NextResponse("Unauthorized", { status: 403 });
+  }
+  const { type, amount, mode } = await req.json();
+  if (!type || !amount) {
+    return new NextResponse("Missing fields", { status: 400 });
+  }
+  if (type !== "payment" && type !== "concession") {
+    return new NextResponse("Invalid type", { status: 400 });
+  }
+  if (type === "payment" && mode !== "cash" && mode !== "online") {
+    return new NextResponse("Invalid payment mode", { status: 400 });
+  }
+  const txn = await prisma.transaction.update({
+    where: { id },
+    data: {
+      type,
+      amount: amount.toString(),
+      mode: type === "payment" ? mode : null,
+      approved: type === "payment" ? true : false,
+    },
+    select: {
+      id: true,
+      studentId: true,
+      student: { select: { name: true, batch: true } },
+      createdById: true,
+      type: true,
+      amount: true,
+      mode: true,
+      approved: true,
+      createdAt: true,
+    },
+  });
+  return NextResponse.json({
+    ...txn,
+    amount: txn.amount.toString(),
+    createdAt: txn.createdAt.toISOString(),
+  });
+}
+
 export async function DELETE(
   _req: Request,
   { params }: { params: Promise<{ id: string }> }

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -4,12 +4,15 @@ import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
 import { Prisma } from "@prisma/client";
 
-export async function GET() {
+export async function GET(req: Request) {
   const session = await getServerSession(authOptions);
   if (!session) {
     return new NextResponse("Unauthorized", { status: 403 });
   }
+  const url = new URL(req.url);
+  const studentId = url.searchParams.get("studentId") || undefined;
   const txns = await prisma.transaction.findMany({
+    where: studentId ? { studentId } : undefined,
     select: {
       id: true,
       studentId: true,

--- a/app/students/StudentsClient.tsx
+++ b/app/students/StudentsClient.tsx
@@ -1,40 +1,13 @@
 "use client";
 import { useState, FormEvent } from "react";
 
-export type Student = {
-  id: string;
-  name: string;
-  batch: string;
-  totalFee: string;
-};
-
-export default function StudentsClient({
-  initialStudents,
-  isAdmin,
-}: {
-  initialStudents: Student[];
-  isAdmin: boolean;
-}) {
-  const [students, setStudents] = useState<Student[]>(initialStudents);
+export default function StudentsClient() {
   const [name, setName] = useState("");
   const [batch, setBatch] = useState("");
   const [totalFee, setTotalFee] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [editing, setEditing] = useState<Student | null>(null);
-  const [editName, setEditName] = useState("");
-  const [editBatch, setEditBatch] = useState("");
-  const [editTotalFee, setEditTotalFee] = useState("");
-  const [editError, setEditError] = useState<string | null>(null);
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
-
-  async function refresh() {
-    const res = await fetch("/api/students");
-    if (res.ok) {
-      const data = await res.json();
-      setStudents(data);
-    }
-  }
 
   async function addStudent(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -53,7 +26,6 @@ export default function StudentsClient({
     setName("");
     setBatch("");
     setTotalFee("");
-    refresh();
   }
 
   async function importStudents(e: FormEvent<HTMLFormElement>) {
@@ -86,45 +58,8 @@ export default function StudentsClient({
     }
     setCsvFile(null);
     (e.target as HTMLFormElement).reset();
-    refresh();
   }
 
-  async function deleteStudent(id: string) {
-    if (!confirm("Delete this student?")) return;
-    await fetch(`/api/students/${id}`, { method: "DELETE" });
-    setStudents((s) => s.filter((st) => st.id !== id));
-  }
-
-  function startEdit(student: Student) {
-    setEditing(student);
-    setEditName(student.name);
-    setEditBatch(student.batch);
-    setEditTotalFee(student.totalFee);
-    setEditError(null);
-  }
-
-  async function updateStudent(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    if (!editing) return;
-    setEditError(null);
-    const res = await fetch(`/api/students/${editing.id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: editName,
-        batch: editBatch,
-        totalFee: editTotalFee,
-      }),
-    });
-    if (!res.ok) {
-      const text = await res.text();
-      setEditError(text);
-      alert(text);
-      return;
-    }
-    setEditing(null);
-    refresh();
-  }
 
   return (
     <div className="p-6 space-y-6 max-w-xl mx-auto">
@@ -165,63 +100,6 @@ export default function StudentsClient({
         </button>
         {importError && <p className="text-red-600">{importError}</p>}
       </form>
-      <ul className="space-y-2">
-        {students.map((s) => (
-          <li key={s.id} className="border p-2 rounded space-y-2">
-            {editing && editing.id === s.id ? (
-              <form onSubmit={updateStudent} className="space-y-2">
-                <input
-                  className="w-full border p-2 rounded"
-                  placeholder="Name"
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                />
-                <input
-                  className="w-full border p-2 rounded"
-                  placeholder="Batch"
-                  value={editBatch}
-                  onChange={(e) => setEditBatch(e.target.value)}
-                />
-                <input
-                  className="w-full border p-2 rounded"
-                  placeholder="Total Fee"
-                  value={editTotalFee}
-                  onChange={(e) => setEditTotalFee(e.target.value)}
-                />
-                <div className="flex gap-2">
-                  <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
-                    Save
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setEditing(null)}
-                    className="px-4 py-2 bg-gray-300 rounded"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                {editError && <p className="text-red-600">{editError}</p>}
-              </form>
-            ) : (
-              <div className="flex justify-between items-center">
-                <span>
-                  {s.name} - {s.batch} - {s.totalFee}
-                </span>
-                {isAdmin && (
-                  <div className="space-x-2">
-                    <button onClick={() => startEdit(s)} className="text-blue-600">
-                      Edit
-                    </button>
-                    <button onClick={() => deleteStudent(s.id)} className="text-red-600">
-                      Delete
-                    </button>
-                  </div>
-                )}
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
     </div>
   );
 }

--- a/app/students/[id]/StudentClient.tsx
+++ b/app/students/[id]/StudentClient.tsx
@@ -1,0 +1,186 @@
+"use client";
+import { useState, FormEvent } from "react";
+
+export type Student = {
+  id: string;
+  name: string;
+  batch: string;
+  totalFee: string;
+};
+
+export type Transaction = {
+  id: string;
+  studentId: string;
+  createdById: string;
+  type: string;
+  amount: string;
+  mode: string | null;
+  approved: boolean;
+  createdAt: string;
+};
+
+export default function StudentClient({
+  student,
+  initialTransactions,
+  isAdmin,
+}: {
+  student: Student;
+  initialTransactions: Transaction[];
+  isAdmin: boolean;
+}) {
+  const [transactions, setTransactions] = useState<Transaction[]>(initialTransactions);
+  const [type, setType] = useState("payment");
+  const [amount, setAmount] = useState("");
+  const [mode, setMode] = useState("cash");
+  const [editing, setEditing] = useState<Transaction | null>(null);
+  const [editType, setEditType] = useState("payment");
+  const [editAmount, setEditAmount] = useState("");
+  const [editMode, setEditMode] = useState("cash");
+
+  async function refresh() {
+    const res = await fetch(`/api/transactions?studentId=${student.id}`);
+    if (res.ok) {
+      const data = await res.json();
+      setTransactions(data);
+    }
+  }
+
+  async function addTransaction(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch("/api/transactions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ studentId: student.id, type, amount, mode }),
+    });
+    setAmount("");
+    refresh();
+  }
+
+  function startEdit(t: Transaction) {
+    setEditing(t);
+    setEditType(t.type);
+    setEditAmount(t.amount);
+    setEditMode(t.mode || "cash");
+  }
+
+  async function updateTransaction(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!editing) return;
+    await fetch(`/api/transactions/${editing.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: editType, amount: editAmount, mode: editMode }),
+    });
+    setEditing(null);
+    refresh();
+  }
+
+  async function deleteTransaction(id: string) {
+    if (!confirm("Delete this transaction?")) return;
+    await fetch(`/api/transactions/${id}`, { method: "DELETE" });
+    refresh();
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-xl font-bold">
+        {student.name} - {student.batch}
+      </h1>
+      <form onSubmit={addTransaction} className="space-y-2 border p-4 rounded">
+        <select
+          className="w-full border p-2 rounded"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+        >
+          <option value="payment">payment</option>
+          <option value="concession">concession</option>
+        </select>
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        {type === "payment" && (
+          <select
+            className="w-full border p-2 rounded"
+            value={mode}
+            onChange={(e) => setMode(e.target.value)}
+          >
+            <option value="cash">cash</option>
+            <option value="online">online</option>
+          </select>
+        )}
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+          Add Transaction
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {transactions.map((t) => (
+          <li key={t.id} className="border p-2 rounded">
+            {editing && editing.id === t.id ? (
+              <form onSubmit={updateTransaction} className="space-y-2">
+                <select
+                  className="w-full border p-2 rounded"
+                  value={editType}
+                  onChange={(e) => setEditType(e.target.value)}
+                >
+                  <option value="payment">payment</option>
+                  <option value="concession">concession</option>
+                </select>
+                <input
+                  className="w-full border p-2 rounded"
+                  placeholder="Amount"
+                  value={editAmount}
+                  onChange={(e) => setEditAmount(e.target.value)}
+                />
+                {editType === "payment" && (
+                  <select
+                    className="w-full border p-2 rounded"
+                    value={editMode}
+                    onChange={(e) => setEditMode(e.target.value)}
+                  >
+                    <option value="cash">cash</option>
+                    <option value="online">online</option>
+                  </select>
+                )}
+                <div className="flex gap-2">
+                  <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    className="px-4 py-2 bg-gray-300 rounded"
+                    onClick={() => setEditing(null)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div className="flex justify-between">
+                <span>
+                  {t.createdAt.slice(0, 10)} - {t.type} {t.amount} {t.mode ? `(${t.mode})` : ""}
+                  {!t.approved && t.type === "concession" && (
+                    <span className="text-orange-600"> Pending</span>
+                  )}
+                </span>
+                {isAdmin && (
+                  <div className="space-x-2">
+                    <button onClick={() => startEdit(t)} className="text-blue-600">
+                      Edit
+                    </button>
+                    <button onClick={() => deleteTransaction(t.id)} className="text-red-600">
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/app/students/[id]/page.tsx
+++ b/app/students/[id]/page.tsx
@@ -1,0 +1,43 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import StudentClient from "./StudentClient";
+
+export default async function StudentPage({ params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect("/login");
+  }
+  const student = await prisma.student.findUnique({
+    where: { id: params.id },
+    select: { id: true, name: true, batch: true, totalFee: true },
+  });
+  if (!student) redirect("/students");
+  const txns = await prisma.transaction.findMany({
+    where: { studentId: params.id },
+    select: {
+      id: true,
+      studentId: true,
+      createdById: true,
+      type: true,
+      amount: true,
+      mode: true,
+      approved: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  const transactions = txns.map((t) => ({
+    ...t,
+    amount: t.amount.toString(),
+    createdAt: t.createdAt.toISOString(),
+  }));
+  return (
+    <StudentClient
+      student={{ ...student, totalFee: student.totalFee.toString() }}
+      initialTransactions={transactions}
+      isAdmin={session.user.role === "admin"}
+    />
+  );
+}

--- a/app/students/[id]/page.tsx
+++ b/app/students/[id]/page.tsx
@@ -4,18 +4,23 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import StudentClient from "./StudentClient";
 
-export default async function StudentPage({ params }: { params: { id: string } }) {
+export default async function StudentPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
   const session = await getServerSession(authOptions);
   if (!session) {
     redirect("/login");
   }
   const student = await prisma.student.findUnique({
-    where: { id: params.id },
+    where: { id },
     select: { id: true, name: true, batch: true, totalFee: true },
   });
   if (!student) redirect("/students");
   const txns = await prisma.transaction.findMany({
-    where: { studentId: params.id },
+    where: { studentId: id },
     select: {
       id: true,
       studentId: true,

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -1,7 +1,6 @@
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
 import StudentsClient from "./StudentsClient";
 
 export default async function StudentsPage() {
@@ -9,17 +8,5 @@ export default async function StudentsPage() {
   if (!session) {
     redirect("/login");
   }
-  const dbStudents = await prisma.student.findMany({
-    select: { id: true, name: true, batch: true, totalFee: true },
-  });
-  const students = dbStudents.map((s) => ({
-    ...s,
-    totalFee: s.totalFee.toString(),
-  }));
-  return (
-    <StudentsClient
-      initialStudents={students}
-      isAdmin={session.user.role === "admin"}
-    />
-  );
+  return <StudentsClient />;
 }


### PR DESCRIPTION
## Summary
- remove student list and editing from students page
- add header search bar for navigating to student pages
- filter students via query param
- filter transactions by studentId and allow updating transactions
- create dynamic student pages for transactions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d48fb90288321ae34c3eca9325c3d