### PR TITLE
Add student profile editing and drop txn edit

### DIFF
--- a/app/students/[id]/StudentClient.tsx
+++ b/app/students/[id]/StudentClient.tsx
@@ -32,10 +32,11 @@ export default function StudentClient({
   const [type, setType] = useState("payment");
   const [amount, setAmount] = useState("");
   const [mode, setMode] = useState("cash");
-  const [editing, setEditing] = useState<Transaction | null>(null);
-  const [editType, setEditType] = useState("payment");
-  const [editAmount, setEditAmount] = useState("");
-  const [editMode, setEditMode] = useState("cash");
+  const [studentInfo, setStudentInfo] = useState(student);
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [editName, setEditName] = useState(student.name);
+  const [editBatch, setEditBatch] = useState(student.batch);
+  const [editTotalFee, setEditTotalFee] = useState(student.totalFee);
 
   async function refresh() {
     const res = await fetch(`/api/transactions?studentId=${student.id}`);
@@ -56,23 +57,25 @@ export default function StudentClient({
     refresh();
   }
 
-  function startEdit(t: Transaction) {
-    setEditing(t);
-    setEditType(t.type);
-    setEditAmount(t.amount);
-    setEditMode(t.mode || "cash");
+  function startProfileEdit() {
+    setEditingProfile(true);
+    setEditName(studentInfo.name);
+    setEditBatch(studentInfo.batch);
+    setEditTotalFee(studentInfo.totalFee);
   }
 
-  async function updateTransaction(e: FormEvent<HTMLFormElement>) {
+  async function updateProfile(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!editing) return;
-    await fetch(`/api/transactions/${editing.id}`, {
+    const res = await fetch(`/api/students/${studentInfo.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ type: editType, amount: editAmount, mode: editMode }),
+      body: JSON.stringify({ name: editName, batch: editBatch, totalFee: editTotalFee }),
     });
-    setEditing(null);
-    refresh();
+    if (res.ok) {
+      const data = await res.json();
+      setStudentInfo(data);
+    }
+    setEditingProfile(false);
   }
 
   async function deleteTransaction(id: string) {
@@ -83,9 +86,50 @@ export default function StudentClient({
 
   return (
     <div className="p-6 space-y-6 max-w-xl mx-auto">
-      <h1 className="text-xl font-bold">
-        {student.name} - {student.batch}
+      <h1 className="text-xl font-bold flex justify-between">
+        <span>
+          {studentInfo.name} - {studentInfo.batch}
+        </span>
+        {isAdmin && !editingProfile && (
+          <button onClick={startProfileEdit} className="text-blue-600">
+            Edit Profile
+          </button>
+        )}
       </h1>
+      {editingProfile && (
+        <form onSubmit={updateProfile} className="space-y-2 border p-4 rounded">
+          <input
+            className="w-full border p-2 rounded"
+            placeholder="Name"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+          />
+          <input
+            className="w-full border p-2 rounded"
+            placeholder="Batch"
+            value={editBatch}
+            onChange={(e) => setEditBatch(e.target.value)}
+          />
+          <input
+            className="w-full border p-2 rounded"
+            placeholder="Total Fee"
+            value={editTotalFee}
+            onChange={(e) => setEditTotalFee(e.target.value)}
+          />
+          <div className="flex gap-2">
+            <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+              Save
+            </button>
+            <button
+              type="button"
+              className="px-4 py-2 bg-gray-300 rounded"
+              onClick={() => setEditingProfile(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
       <form onSubmit={addTransaction} className="space-y-2 border p-4 rounded">
         <select
           className="w-full border p-2 rounded"
@@ -117,65 +161,17 @@ export default function StudentClient({
       </form>
       <ul className="space-y-2">
         {transactions.map((t) => (
-          <li key={t.id} className="border p-2 rounded">
-            {editing && editing.id === t.id ? (
-              <form onSubmit={updateTransaction} className="space-y-2">
-                <select
-                  className="w-full border p-2 rounded"
-                  value={editType}
-                  onChange={(e) => setEditType(e.target.value)}
-                >
-                  <option value="payment">payment</option>
-                  <option value="concession">concession</option>
-                </select>
-                <input
-                  className="w-full border p-2 rounded"
-                  placeholder="Amount"
-                  value={editAmount}
-                  onChange={(e) => setEditAmount(e.target.value)}
-                />
-                {editType === "payment" && (
-                  <select
-                    className="w-full border p-2 rounded"
-                    value={editMode}
-                    onChange={(e) => setEditMode(e.target.value)}
-                  >
-                    <option value="cash">cash</option>
-                    <option value="online">online</option>
-                  </select>
-                )}
-                <div className="flex gap-2">
-                  <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
-                    Save
-                  </button>
-                  <button
-                    type="button"
-                    className="px-4 py-2 bg-gray-300 rounded"
-                    onClick={() => setEditing(null)}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            ) : (
-              <div className="flex justify-between">
-                <span>
-                  {t.createdAt.slice(0, 10)} - {t.type} {t.amount} {t.mode ? `(${t.mode})` : ""}
-                  {!t.approved && t.type === "concession" && (
-                    <span className="text-orange-600"> Pending</span>
-                  )}
-                </span>
-                {isAdmin && (
-                  <div className="space-x-2">
-                    <button onClick={() => startEdit(t)} className="text-blue-600">
-                      Edit
-                    </button>
-                    <button onClick={() => deleteTransaction(t.id)} className="text-red-600">
-                      Delete
-                    </button>
-                  </div>
-                )}
-              </div>
+          <li key={t.id} className="border p-2 rounded flex justify-between">
+            <span>
+              {t.createdAt.slice(0, 10)} - {t.type} {t.amount} {t.mode ? `(${t.mode})` : ""}
+              {!t.approved && t.type === "concession" && (
+                <span className="text-orange-600"> Pending</span>
+              )}
+            </span>
+            {isAdmin && (
+              <button onClick={() => deleteTransaction(t.id)} className="text-red-600">
+                Delete
+              </button>
             )}
           </li>
         ))}


### PR DESCRIPTION
## Summary
- remove transaction editing form from student page
- add profile editing form for student details

## Testing
- `npx next lint` *(fails: prompts to configure ESLint)*
- `pnpm build` *(fails: cannot fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684d68e03acc8321aedafaad61d0825e