### PR TITLE
Handle duplicate usernames

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -25,9 +26,19 @@ export async function POST(req: Request) {
     return new NextResponse("Missing fields", { status: 400 });
   }
   const passwordHash = await bcrypt.hash(password, 10);
-  const user = await prisma.user.create({
-    data: { username, passwordHash, role: role === "admin" ? "admin" : "user" },
-    select: { id: true, username: true, role: true },
-  });
-  return NextResponse.json(user, { status: 201 });
+  try {
+    const user = await prisma.user.create({
+      data: { username, passwordHash, role: role === "admin" ? "admin" : "user" },
+      select: { id: true, username: true, role: true },
+    });
+    return NextResponse.json(user, { status: 201 });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return new NextResponse("Username already exists", { status: 400 });
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary
- throw a 400 when creating a user that already exists

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854187940688321b16ab32e417a7b66