### PR TITLE
Fix button and table contrast

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -19,18 +19,20 @@ export default function Login() {
         </h1>
         <input
           placeholder="Username"
-          className="input input-bordered w-full"
+          className="w-full border p-2 rounded text-black"
           value={username}
           onChange={(e) => setU(e.target.value)}
         />
         <input
           type="password"
           placeholder="Password"
-          className="input input-bordered w-full"
+          className="w-full border p-2 rounded text-black"
           value={password}
           onChange={(e) => setP(e.target.value)}
         />
-        <button className="btn btn-primary w-full">Sign in</button>
+        <button className="w-full px-4 py-2 bg-blue-600 text-white rounded">
+          Sign in
+        </button>
       </form>
     </div>
   );

--- a/app/reports/ReportsClient.tsx
+++ b/app/reports/ReportsClient.tsx
@@ -106,14 +106,14 @@ export default function ReportsClient({ students }: { students: Student[] }) {
         <button
           type="button"
           onClick={() => setReportType("balance")}
-          className={`px-4 py-2 rounded ${reportType === "balance" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+          className={`px-4 py-2 rounded ${reportType === "balance" ? "bg-blue-600 text-white" : "bg-gray-200 text-black dark:bg-gray-700 dark:text-white"}`}
         >
           Balance Reports
         </button>
         <button
           type="button"
           onClick={() => setReportType("transactions")}
-          className={`px-4 py-2 rounded ${reportType === "transactions" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+          className={`px-4 py-2 rounded ${reportType === "transactions" ? "bg-blue-600 text-white" : "bg-gray-200 text-black dark:bg-gray-700 dark:text-white"}`}
         >
           Transaction Reports
         </button>
@@ -124,7 +124,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
           <form onSubmit={getBalances} className="space-y-2 border p-4 rounded">
             <h2 className="font-semibold">Student Balances</h2>
             <select
-              className="w-full border p-2 rounded"
+              className="w-full border p-2 rounded text-black"
               value={batch}
               onChange={(e) => setBatch(e.target.value)}
             >
@@ -136,7 +136,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
               ))}
             </select>
             <input
-              className="w-full border p-2 rounded"
+              className="w-full border p-2 rounded text-black"
               placeholder="Name (optional)"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -150,36 +150,36 @@ export default function ReportsClient({ students }: { students: Student[] }) {
             <>
               <table className="min-w-full border">
                 <thead>
-                  <tr className="bg-gray-100">
-                    <th className="border px-2 py-1 text-left">S.No.</th>
-                    <th className="border px-2 py-1 text-left">Name</th>
-                    <th className="border px-2 py-1 text-left">Batch</th>
-                    <th className="border px-2 py-1 text-left">Total Fee</th>
-                    <th className="border px-2 py-1 text-left">Balance</th>
+                  <tr className="bg-gray-100 dark:bg-gray-800">
+                    <th className="border px-2 py-1 text-left text-black dark:text-gray-200">S.No.</th>
+                    <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Name</th>
+                    <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Batch</th>
+                    <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Total Fee</th>
+                    <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Balance</th>
                   </tr>
                 </thead>
                 <tbody>
                   {balances.map((b, i) => (
-                    <tr key={b.id} className="odd:bg-white even:bg-gray-50">
-                      <td className="border px-2 py-1">{i + 1}</td>
-                      <td className="border px-2 py-1">{b.name}</td>
-                      <td className="border px-2 py-1">{b.batch}</td>
-                      <td className="border px-2 py-1">{b.totalFee}</td>
-                      <td className="border px-2 py-1">{b.balance}</td>
+                    <tr key={b.id} className="odd:bg-white even:bg-gray-50 dark:odd:bg-gray-800 dark:even:bg-gray-700">
+                      <td className="border px-2 py-1 text-black dark:text-gray-200">{i + 1}</td>
+                      <td className="border px-2 py-1 text-black dark:text-gray-200">{b.name}</td>
+                      <td className="border px-2 py-1 text-black dark:text-gray-200">{b.batch}</td>
+                      <td className="border px-2 py-1 text-black dark:text-gray-200">{b.totalFee}</td>
+                      <td className="border px-2 py-1 text-black dark:text-gray-200">{b.balance}</td>
                     </tr>
                   ))}
                 </tbody>
                 <tfoot>
                   <tr className="font-semibold">
-                    <td className="border px-2 py-1" colSpan={3}>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200" colSpan={3}>
                       Total
                     </td>
-                    <td className="border px-2 py-1">
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">
                       {balances
                         .reduce((sum, b) => sum + parseFloat(b.totalFee), 0)
                         .toFixed(2)}
                     </td>
-                    <td className="border px-2 py-1">
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">
                       {balances
                         .reduce((sum, b) => sum + parseFloat(b.balance), 0)
                         .toFixed(2)}
@@ -204,7 +204,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
           <form onSubmit={getTransactions} className="space-y-2 border p-4 rounded">
             <h2 className="font-semibold">Transactions</h2>
             <select
-              className="w-full border p-2 rounded"
+              className="w-full border p-2 rounded text-black"
               value={tBatch}
               onChange={(e) => setTBatch(e.target.value)}
             >
@@ -216,7 +216,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
               ))}
             </select>
             <input
-              className="w-full border p-2 rounded"
+              className="w-full border p-2 rounded text-black"
               placeholder="Name (optional)"
               value={tName}
               onChange={(e) => setTName(e.target.value)}
@@ -224,13 +224,13 @@ export default function ReportsClient({ students }: { students: Student[] }) {
             <div className="flex gap-2">
               <input
                 type="date"
-                className="w-full border p-2 rounded"
+                className="w-full border p-2 rounded text-black"
                 value={start}
                 onChange={(e) => setStart(e.target.value)}
               />
               <input
                 type="date"
-                className="w-full border p-2 rounded"
+                className="w-full border p-2 rounded text-black"
                 value={end}
                 onChange={(e) => setEnd(e.target.value)}
               />

--- a/app/students/StudentsClient.tsx
+++ b/app/students/StudentsClient.tsx
@@ -66,19 +66,19 @@ export default function StudentsClient() {
       <h1 className="text-xl font-bold">Students</h1>
       <form onSubmit={addStudent} className="space-y-2 border p-4 rounded">
         <input
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           placeholder="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <input
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           placeholder="Batch"
           value={batch}
           onChange={(e) => setBatch(e.target.value)}
         />
         <input
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           placeholder="Total Fee"
           value={totalFee}
           onChange={(e) => setTotalFee(e.target.value)}

--- a/app/students/[id]/StudentClient.tsx
+++ b/app/students/[id]/StudentClient.tsx
@@ -99,19 +99,19 @@ export default function StudentClient({
       {editingProfile && (
         <form onSubmit={updateProfile} className="space-y-2 border p-4 rounded">
           <input
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded text-black"
             placeholder="Name"
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
           />
           <input
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded text-black"
             placeholder="Batch"
             value={editBatch}
             onChange={(e) => setEditBatch(e.target.value)}
           />
           <input
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded text-black"
             placeholder="Total Fee"
             value={editTotalFee}
             onChange={(e) => setEditTotalFee(e.target.value)}
@@ -122,7 +122,7 @@ export default function StudentClient({
             </button>
             <button
               type="button"
-              className="px-4 py-2 bg-gray-300 rounded"
+              className="px-4 py-2 bg-gray-300 dark:bg-gray-700 rounded text-black dark:text-white"
               onClick={() => setEditingProfile(false)}
             >
               Cancel
@@ -132,7 +132,7 @@ export default function StudentClient({
       )}
       <form onSubmit={addTransaction} className="space-y-2 border p-4 rounded">
         <select
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           value={type}
           onChange={(e) => setType(e.target.value)}
         >
@@ -140,14 +140,14 @@ export default function StudentClient({
           <option value="concession">concession</option>
         </select>
         <input
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           placeholder="Amount"
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
         />
         {type === "payment" && (
           <select
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded text-black"
             value={mode}
             onChange={(e) => setMode(e.target.value)}
           >

--- a/app/transactions/TransactionsClient.tsx
+++ b/app/transactions/TransactionsClient.tsx
@@ -64,7 +64,7 @@ export default function TransactionsClient({
       <h1 className="text-xl font-bold">Transactions</h1>
       <form onSubmit={addTransaction} className="space-y-2 border p-4 rounded">
         <select
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           value={studentId}
           onChange={(e) => setStudentId(e.target.value)}
         >
@@ -75,7 +75,7 @@ export default function TransactionsClient({
           ))}
         </select>
         <select
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           value={type}
           onChange={(e) => setType(e.target.value)}
         >
@@ -83,14 +83,14 @@ export default function TransactionsClient({
           <option value="concession">concession</option>
         </select>
         <input
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           placeholder="Amount"
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
         />
         {type === "payment" && (
           <select
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded text-black"
             value={mode}
             onChange={(e) => setMode(e.target.value)}
           >

--- a/app/users/UsersClient.tsx
+++ b/app/users/UsersClient.tsx
@@ -73,20 +73,20 @@ export default function UsersClient({
       <h1 className="text-xl font-bold">Users</h1>
       <form onSubmit={addUser} className="space-y-2 border p-4 rounded">
         <input
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           placeholder="Username"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
         />
         <input
           type="password"
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
         <select
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded text-black"
           value={role}
           onChange={(e) => setRole(e.target.value)}
         >
@@ -103,20 +103,20 @@ export default function UsersClient({
             {editing && editing.id === u.id ? (
               <form onSubmit={updateUser} className="space-y-2">
                 <input
-                  className="w-full border p-2 rounded"
+                  className="w-full border p-2 rounded text-black"
                   placeholder="Username"
                   value={editUsername}
                   onChange={(e) => setEditUsername(e.target.value)}
                 />
                 <input
                   type="password"
-                  className="w-full border p-2 rounded"
+                  className="w-full border p-2 rounded text-black"
                   placeholder="Password (leave blank to keep)"
                   value={editPassword}
                   onChange={(e) => setEditPassword(e.target.value)}
                 />
                 <select
-                  className="w-full border p-2 rounded"
+                  className="w-full border p-2 rounded text-black"
                   value={editRole}
                   onChange={(e) => setEditRole(e.target.value)}
                 >
@@ -130,7 +130,7 @@ export default function UsersClient({
                   <button
                     type="button"
                     onClick={() => setEditing(null)}
-                    className="px-4 py-2 bg-gray-300 rounded"
+                    className="px-4 py-2 bg-gray-300 dark:bg-gray-700 rounded text-black dark:text-white"
                   >
                     Cancel
                   </button>


### PR DESCRIPTION
## Summary
- make login form use Tailwind classes instead of undefined `btn` classes
- set dark-mode friendly colours for report type buttons and tables
- ensure input fields use dark text
- adjust cancel buttons for dark mode

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685432b3af548321a7c780e335d76f9a