### PR TITLE
Fix Balance PDF table

### DIFF
--- a/app/reports/ReportsClient.tsx
+++ b/app/reports/ReportsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, FormEvent } from "react";
 import { jsPDF } from "jspdf";
+import autoTable from "jspdf-autotable";
 
 export type Student = { id: string; name: string; batch: string };
 export type Transaction = {
@@ -38,20 +39,17 @@ export default function ReportsClient({ students }: { students: Student[] }) {
 
   function downloadBalancesPdf() {
     const doc = new jsPDF();
-    doc.text("Student Balances", 10, 10);
-    balances.forEach((b, i) => {
-      const line = `${i + 1}. ${b.name} - ${b.batch}: Fee ${b.totalFee} Balance ${b.balance}`;
-      doc.text(line, 10, 20 + i * 10);
-    });
+    doc.text("Student Balances", 14, 10);
     if (balances.length > 0) {
-      const totalFee = balances
-        .reduce((sum, b) => sum + parseFloat(b.totalFee), 0)
-        .toFixed(2);
-      const totalBal = balances
-        .reduce((sum, b) => sum + parseFloat(b.balance), 0)
-        .toFixed(2);
-      const y = 20 + balances.length * 10 + 10;
-      doc.text(`Total  ${totalFee}  ${totalBal}`, 10, y);
+      const totalFee = balances.reduce((sum, b) => sum + parseFloat(b.totalFee), 0).toFixed(2);
+      const totalBal = balances.reduce((sum, b) => sum + parseFloat(b.balance), 0).toFixed(2);
+      autoTable(doc, {
+        head: [["S.No.", "Name", "Batch", "Total Fee", "Balance"]],
+        body: balances.map((b, i) => [i + 1, b.name, b.batch, b.totalFee, b.balance]),
+        foot: [[{ content: "Total", colSpan: 3 }, totalFee, totalBal]],
+        startY: 20,
+        theme: "grid",
+      });
     }
     doc.save("balances.pdf");
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@prisma/client": "^6.9.0",
     "bcryptjs": "^3.0.2",
     "jspdf": "^3.0.1",
+    "jspdf-autotable": "^5.0.2",
     "next": "15.3.3",
     "next-auth": "^4.24.11",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       jspdf:
         specifier: ^3.0.1
         version: 3.0.1
+      jspdf-autotable:
+        specifier: ^5.0.2
+        version: 5.0.2(jspdf@3.0.1)
       next:
         specifier: 15.3.3
         version: 15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -520,6 +523,11 @@ packages:
 
   jose@6.0.11:
     resolution: {integrity: sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==}
+
+  jspdf-autotable@5.0.2:
+    resolution: {integrity: sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==}
+    peerDependencies:
+      jspdf: ^2 || ^3
 
   jspdf@3.0.1:
     resolution: {integrity: sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==}
@@ -1192,6 +1200,10 @@ snapshots:
   jose@4.15.9: {}
 
   jose@6.0.11: {}
+
+  jspdf-autotable@5.0.2(jspdf@3.0.1):
+    dependencies:
+      jspdf: 3.0.1
 
   jspdf@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- use `jspdf-autotable` to render the balance report table in the PDF
- add `jspdf-autotable` to dependencies

## Testing
- `pnpm build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6854340d91708321be3100eaf5ac4a55