### PR TITLE
Improve dark mode styling

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -19,18 +19,18 @@ export default function Login() {
         </h1>
         <input
           placeholder="Username"
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           value={username}
           onChange={(e) => setU(e.target.value)}
         />
         <input
           type="password"
           placeholder="Password"
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           value={password}
           onChange={(e) => setP(e.target.value)}
         />
-        <button className="w-full px-4 py-2 bg-blue-600 text-white rounded">
+        <button className="w-full px-4 py-2 rounded bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 text-white">
           Sign in
         </button>
       </form>

--- a/app/reports/ReportsClient.tsx
+++ b/app/reports/ReportsClient.tsx
@@ -127,14 +127,14 @@ export default function ReportsClient({ students }: { students: Student[] }) {
         <button
           type="button"
           onClick={() => setReportType("balance")}
-          className={`px-4 py-2 rounded ${reportType === "balance" ? "bg-blue-600 text-white" : "bg-gray-200 text-black dark:bg-gray-700 dark:text-white"}`}
+          className={`px-4 py-2 rounded ${reportType === "balance" ? "bg-blue-600 text-white" : "bg-gray-200 text-black dark:bg-gray-700 dark:text-gray-100"}`}
         >
           Balance Reports
         </button>
         <button
           type="button"
           onClick={() => setReportType("transactions")}
-          className={`px-4 py-2 rounded ${reportType === "transactions" ? "bg-blue-600 text-white" : "bg-gray-200 text-black dark:bg-gray-700 dark:text-white"}`}
+          className={`px-4 py-2 rounded ${reportType === "transactions" ? "bg-blue-600 text-white" : "bg-gray-200 text-black dark:bg-gray-700 dark:text-gray-100"}`}
         >
           Transaction Reports
         </button>
@@ -145,7 +145,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
           <form onSubmit={getBalances} className="space-y-2 border p-4 rounded bg-white dark:bg-gray-900">
             <h2 className="font-semibold">Student Balances</h2>
             <select
-              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
               value={batch}
               onChange={(e) => setBatch(e.target.value)}
             >
@@ -157,7 +157,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
               ))}
             </select>
             <input
-              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
               placeholder="Name (optional)"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -225,7 +225,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
           <form onSubmit={getTransactions} className="space-y-2 border p-4 rounded bg-white dark:bg-gray-900">
             <h2 className="font-semibold">Transactions</h2>
             <select
-              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
               value={tBatch}
               onChange={(e) => setTBatch(e.target.value)}
             >
@@ -237,7 +237,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
               ))}
             </select>
             <input
-              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+              className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
               placeholder="Name (optional)"
               value={tName}
               onChange={(e) => setTName(e.target.value)}
@@ -245,13 +245,13 @@ export default function ReportsClient({ students }: { students: Student[] }) {
             <div className="flex gap-2">
               <input
                 type="date"
-                className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+                className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
                 value={start}
                 onChange={(e) => setStart(e.target.value)}
               />
               <input
                 type="date"
-                className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+                className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
                 value={end}
                 onChange={(e) => setEnd(e.target.value)}
               />
@@ -263,43 +263,43 @@ export default function ReportsClient({ students }: { students: Student[] }) {
           {transactions.length > 0 ? (
             <table className="min-w-full border mt-2">
               <thead>
-                <tr className="bg-gray-100">
-                  <th className="border px-2 py-1 text-left">S.No.</th>
-                  <th className="border px-2 py-1 text-left">Date</th>
-                  <th className="border px-2 py-1 text-left">Name</th>
-                  <th className="border px-2 py-1 text-left">Batch</th>
-                  <th className="border px-2 py-1 text-left">Amount</th>
-                  <th className="border px-2 py-1 text-left">Payment Mode</th>
+                <tr className="bg-gray-100 dark:bg-gray-800">
+                  <th className="border px-2 py-1 text-left text-black dark:text-gray-200">S.No.</th>
+                  <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Date</th>
+                  <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Name</th>
+                  <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Batch</th>
+                  <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Amount</th>
+                  <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Payment Mode</th>
                 </tr>
               </thead>
               <tbody>
                 {transactions.map((t, i) => (
-                  <tr key={t.id} className="odd:bg-white even:bg-gray-50">
-                    <td className="border px-2 py-1">{i + 1}</td>
-                    <td className="border px-2 py-1">
+                  <tr key={t.id} className="odd:bg-white even:bg-gray-50 dark:odd:bg-gray-800 dark:even:bg-gray-700">
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">{i + 1}</td>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">
                       {t.createdAt.slice(0, 10)}
                     </td>
-                    <td className="border px-2 py-1">{t.student.name}</td>
-                    <td className="border px-2 py-1">{t.student.batch}</td>
-                    <td className="border px-2 py-1">{t.amount}</td>
-                    <td className="border px-2 py-1">{t.mode}</td>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">{t.student.name}</td>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">{t.student.batch}</td>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">{t.amount}</td>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">{t.mode}</td>
                   </tr>
                 ))}
               </tbody>
               <tfoot>
                 {totals.map((t) => (
                   <tr key={t.mode} className="font-semibold">
-                    <td className="border px-2 py-1" colSpan={5}>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200" colSpan={5}>
                       Total {t.mode}
                     </td>
-                    <td className="border px-2 py-1">{t.amount}</td>
+                    <td className="border px-2 py-1 text-black dark:text-gray-200">{t.amount}</td>
                   </tr>
                 ))}
                 <tr className="font-semibold">
-                  <td className="border px-2 py-1" colSpan={5}>
+                  <td className="border px-2 py-1 text-black dark:text-gray-200" colSpan={5}>
                     Total
                   </td>
-                  <td className="border px-2 py-1">
+                  <td className="border px-2 py-1 text-black dark:text-gray-200">
                     {transactions
                       .reduce((sum, t) => sum + parseFloat(t.amount), 0)
                       .toFixed(2)}

--- a/app/students/StudentsClient.tsx
+++ b/app/students/StudentsClient.tsx
@@ -66,19 +66,19 @@ export default function StudentsClient() {
       <h1 className="text-xl font-bold">Students</h1>
       <form onSubmit={addStudent} className="space-y-2 border p-4 rounded bg-white dark:bg-gray-900">
         <input
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           placeholder="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <input
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           placeholder="Batch"
           value={batch}
           onChange={(e) => setBatch(e.target.value)}
         />
         <input
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           placeholder="Total Fee"
           value={totalFee}
           onChange={(e) => setTotalFee(e.target.value)}

--- a/app/students/[id]/StudentClient.tsx
+++ b/app/students/[id]/StudentClient.tsx
@@ -99,19 +99,19 @@ export default function StudentClient({
       {editingProfile && (
         <form onSubmit={updateProfile} className="space-y-2 border p-4 rounded bg-white dark:bg-gray-900">
           <input
-            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
             placeholder="Name"
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
           />
           <input
-            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
             placeholder="Batch"
             value={editBatch}
             onChange={(e) => setEditBatch(e.target.value)}
           />
           <input
-            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
             placeholder="Total Fee"
             value={editTotalFee}
             onChange={(e) => setEditTotalFee(e.target.value)}
@@ -122,7 +122,7 @@ export default function StudentClient({
             </button>
             <button
               type="button"
-              className="px-4 py-2 bg-gray-300 dark:bg-gray-700 rounded text-black dark:text-white"
+              className="px-4 py-2 bg-gray-300 hover:bg-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 rounded text-black dark:text-gray-100"
               onClick={() => setEditingProfile(false)}
             >
               Cancel
@@ -132,7 +132,7 @@ export default function StudentClient({
       )}
       <form onSubmit={addTransaction} className="space-y-2 border p-4 rounded bg-white dark:bg-gray-900">
         <select
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           value={type}
           onChange={(e) => setType(e.target.value)}
         >
@@ -140,14 +140,14 @@ export default function StudentClient({
           <option value="concession">concession</option>
         </select>
         <input
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           placeholder="Amount"
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
         />
         {type === "payment" && (
           <select
-            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
             value={mode}
             onChange={(e) => setMode(e.target.value)}
           >

--- a/app/transactions/TransactionsClient.tsx
+++ b/app/transactions/TransactionsClient.tsx
@@ -64,7 +64,7 @@ export default function TransactionsClient({
       <h1 className="text-xl font-bold">Transactions</h1>
       <form onSubmit={addTransaction} className="space-y-2 border p-4 rounded bg-white dark:bg-gray-900">
         <select
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           value={studentId}
           onChange={(e) => setStudentId(e.target.value)}
         >
@@ -75,7 +75,7 @@ export default function TransactionsClient({
           ))}
         </select>
         <select
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           value={type}
           onChange={(e) => setType(e.target.value)}
         >
@@ -83,14 +83,14 @@ export default function TransactionsClient({
           <option value="concession">concession</option>
         </select>
         <input
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           placeholder="Amount"
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
         />
         {type === "payment" && (
           <select
-            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+            className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
             value={mode}
             onChange={(e) => setMode(e.target.value)}
           >

--- a/app/users/UsersClient.tsx
+++ b/app/users/UsersClient.tsx
@@ -73,20 +73,20 @@ export default function UsersClient({
       <h1 className="text-xl font-bold">Users</h1>
       <form onSubmit={addUser} className="space-y-2 border p-4 rounded bg-white dark:bg-gray-900">
         <input
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           placeholder="Username"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
         />
         <input
           type="password"
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
         <select
-          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+          className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
           value={role}
           onChange={(e) => setRole(e.target.value)}
         >
@@ -103,20 +103,20 @@ export default function UsersClient({
             {editing && editing.id === u.id ? (
               <form onSubmit={updateUser} className="space-y-2">
                 <input
-                  className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+                  className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
                   placeholder="Username"
                   value={editUsername}
                   onChange={(e) => setEditUsername(e.target.value)}
                 />
                 <input
                   type="password"
-                  className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+                  className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
                   placeholder="Password (leave blank to keep)"
                   value={editPassword}
                   onChange={(e) => setEditPassword(e.target.value)}
                 />
                 <select
-                  className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-white"
+                  className="w-full border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
                   value={editRole}
                   onChange={(e) => setEditRole(e.target.value)}
                 >
@@ -130,7 +130,7 @@ export default function UsersClient({
                   <button
                     type="button"
                     onClick={() => setEditing(null)}
-                    className="px-4 py-2 bg-gray-300 dark:bg-gray-700 rounded text-black dark:text-white"
+                    className="px-4 py-2 bg-gray-300 hover:bg-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 rounded text-black dark:text-gray-100"
                   >
                     Cancel
                   </button>


### PR DESCRIPTION
## Summary
- use Tailwind utilities for login page button
- ensure inputs have dark text and tweak report type buttons
- dark-mode colours for transactions report tables
- improve cancel button styles

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685438a07b2c83218d67e37c0c1483a6