### PR TITLE
Update transaction report totals

### DIFF
--- a/app/api/reports/transactions/route.ts
+++ b/app/api/reports/transactions/route.ts
@@ -51,6 +51,7 @@ export async function GET(req: Request) {
     ...t,
     amount: t.amount.toString(),
     createdAt: t.createdAt.toISOString(),
+    mode: t.type === "concession" ? "concession" : t.mode,
   }));
 
   const modeTotalsRaw = await prisma.transaction.groupBy({
@@ -63,5 +64,11 @@ export async function GET(req: Request) {
     amount: m._sum.amount?.toString() || "0",
   }));
 
-  return NextResponse.json({ transactions, totals });
+  const concessionAgg = await prisma.transaction.aggregate({
+    where: { ...where, type: "concession" },
+    _sum: { amount: true },
+  });
+  const concessionTotal = concessionAgg._sum.amount?.toString() || "0";
+
+  return NextResponse.json({ transactions, totals, concessionTotal });
 }

--- a/app/reports/ReportsClient.tsx
+++ b/app/reports/ReportsClient.tsx
@@ -9,7 +9,7 @@ export type Transaction = {
   student: { name: string; batch: string };
   type: string;
   amount: string;
-  mode: string | null;
+  mode: string;
   approved: boolean;
   createdAt: string;
 };
@@ -36,6 +36,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
   const [end, setEnd] = useState("");
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [totals, setTotals] = useState<{ mode: string; amount: string }[]>([]);
+  const [concessionTotal, setConcessionTotal] = useState("0");
 
   function downloadBalancesPdf() {
     const doc = new jsPDF();
@@ -58,7 +59,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
     const doc = new jsPDF();
     doc.text("Transactions", 14, 10);
     if (transactions.length > 0) {
-      const totalAmount = transactions
+      const paymentTotal = totals
         .reduce((sum, t) => sum + parseFloat(t.amount), 0)
         .toFixed(2);
       const footRows = [
@@ -66,7 +67,8 @@ export default function ReportsClient({ students }: { students: Student[] }) {
           { content: `Total ${t.mode}`, colSpan: 5 },
           t.amount,
         ]),
-        [{ content: "Total", colSpan: 5 }, totalAmount],
+        [{ content: "Total Concession", colSpan: 5 }, concessionTotal],
+        [{ content: "Total", colSpan: 5 }, paymentTotal],
       ];
       autoTable(doc, {
         head: [[
@@ -83,7 +85,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
           t.student.name,
           t.student.batch,
           t.amount,
-          t.mode || "",
+          t.mode,
         ]),
         foot: footRows,
         startY: 20,
@@ -117,6 +119,7 @@ export default function ReportsClient({ students }: { students: Student[] }) {
       const data = await res.json();
       setTransactions(data.transactions);
       setTotals(data.totals);
+      setConcessionTotal(data.concessionTotal);
     }
   }
 
@@ -297,10 +300,16 @@ export default function ReportsClient({ students }: { students: Student[] }) {
                 ))}
                 <tr className="font-semibold">
                   <td className="border px-2 py-1" colSpan={5}>
+                    Total Concession
+                  </td>
+                  <td className="border px-2 py-1">{concessionTotal}</td>
+                </tr>
+                <tr className="font-semibold">
+                  <td className="border px-2 py-1" colSpan={5}>
                     Total
                   </td>
                   <td className="border px-2 py-1">
-                    {transactions
+                    {totals
                       .reduce((sum, t) => sum + parseFloat(t.amount), 0)
                       .toFixed(2)}
                   </td>


### PR DESCRIPTION
## Summary
- show `concession` as a payment mode for concession transactions
- add concession totals in transaction report
- exclude concessions from the overall total

## Testing
- `pnpm install` *(fails: binaries.prisma.sh blocked)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685438e764d483219218ea529aa14111