### PR TITLE
Student list on home page

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,0 +1,99 @@
+"use client";
+import { useState, useEffect, FormEvent } from "react";
+import Link from "next/link";
+import { formatInr } from "@/lib/format";
+
+type Student = {
+  id: string;
+  name: string;
+  batch: string;
+  totalFee: string;
+  balance: string;
+};
+
+export default function HomeClient() {
+  const [batch, setBatch] = useState("");
+  const [name, setName] = useState("");
+  const [students, setStudents] = useState<Student[]>([]);
+  const [filtered, setFiltered] = useState<Student[]>([]);
+
+  async function fetchStudents() {
+    const res = await fetch("/api/reports/balance");
+    if (res.ok) {
+      const data = await res.json();
+      setStudents(data);
+      setFiltered(data);
+    }
+  }
+
+  useEffect(() => {
+    fetchStudents();
+  }, []);
+
+  function applyFilters() {
+    const b = batch.trim();
+    const n = name.trim().toLowerCase();
+    setFiltered(
+      students.filter(
+        (s) =>
+          (b === "" || s.batch === b) &&
+          (n === "" || s.name.toLowerCase().includes(n))
+      )
+    );
+  }
+
+  function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    applyFilters();
+  }
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={submit} className="flex gap-2 flex-wrap items-end">
+        <input
+          className="border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
+          placeholder="Batch"
+          value={batch}
+          onChange={(e) => setBatch(e.target.value)}
+        />
+        <input
+          className="border p-2 rounded bg-white text-black dark:bg-gray-800 dark:text-gray-100"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">
+          Filter
+        </button>
+      </form>
+      {filtered.length === 0 ? (
+        <p>No students found</p>
+      ) : (
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100 dark:bg-gray-800">
+              <th className="border px-2 py-1 text-left text-black dark:text-gray-200">S. No.</th>
+              <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Name</th>
+              <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Batch</th>
+              <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Total Fee</th>
+              <th className="border px-2 py-1 text-left text-black dark:text-gray-200">Balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((s, i) => (
+              <tr key={s.id} className="odd:bg-white even:bg-gray-50 dark:odd:bg-gray-800 dark:even:bg-gray-700">
+                <td className="border px-2 py-1 text-black dark:text-gray-200">{i + 1}</td>
+                <td className="border px-2 py-1 text-blue-600 hover:underline text-black dark:text-gray-200">
+                  <Link href={`/students/${s.id}`}>{s.name}</Link>
+                </td>
+                <td className="border px-2 py-1 text-black dark:text-gray-200">{s.batch}</td>
+                <td className="border px-2 py-1 text-black dark:text-gray-200">{formatInr(s.totalFee)}</td>
+                <td className="border px-2 py-1 text-black dark:text-gray-200">{formatInr(s.balance)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect, FormEvent } from "react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { formatInr } from "@/lib/format";
 
 type Student = {
@@ -12,6 +12,7 @@ type Student = {
 };
 
 export default function HomeClient() {
+  const router = useRouter();
   const [batch, setBatch] = useState("");
   const [name, setName] = useState("");
   const [students, setStudents] = useState<Student[]>([]);
@@ -81,11 +82,13 @@ export default function HomeClient() {
           </thead>
           <tbody>
             {filtered.map((s, i) => (
-              <tr key={s.id} className="odd:bg-white even:bg-gray-50 dark:odd:bg-gray-800 dark:even:bg-gray-700">
+              <tr
+                key={s.id}
+                onClick={() => router.push(`/students/${s.id}`)}
+                className="odd:bg-white even:bg-gray-50 dark:odd:bg-gray-800 dark:even:bg-gray-700 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600"
+              >
                 <td className="border px-2 py-1 text-black dark:text-gray-200">{i + 1}</td>
-                <td className="border px-2 py-1 text-blue-600 hover:underline text-black dark:text-gray-200">
-                  <Link href={`/students/${s.id}`}>{s.name}</Link>
-                </td>
+                <td className="border px-2 py-1 text-black dark:text-gray-200">{s.name}</td>
                 <td className="border px-2 py-1 text-black dark:text-gray-200">{s.batch}</td>
                 <td className="border px-2 py-1 text-black dark:text-gray-200">{formatInr(s.totalFee)}</td>
                 <td className="border px-2 py-1 text-black dark:text-gray-200">{formatInr(s.balance)}</td>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,15 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import HomeClient from "./HomeClient";
 
 export default async function Home() {
   const session = await getServerSession(authOptions);
   return (
-    <div className="p-6 text-center space-y-4">
-      <h1 className="text-2xl font-bold">
-        Welcome to Jagannatha Group B.Ed Colleges Fee Portal
-      </h1>
+    <div className="p-6 space-y-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold">List of Students</h1>
       {session ? (
-        <p>Use the navigation above to manage students.</p>
+        <HomeClient />
       ) : (
         <p>
           <Link href="/login" className="text-blue-600 underline">


### PR DESCRIPTION
## Summary
- show student list on the home page
- enable filtering by batch or name
- link each student to their page
- avoid extra DB calls by filtering client-side

## Testing
- `pnpm install` *(fails: cannot download Prisma engine)*
- `pnpm lint` *(fails: Next.js ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68550341ccfc83218301a3815699a5bb